### PR TITLE
Remove Nikon D500 from Supported Cameras article

### DIFF
--- a/Base.lproj/HelpCentre/SupportedCameras/index.html
+++ b/Base.lproj/HelpCentre/SupportedCameras/index.html
@@ -34,7 +34,6 @@
 <ul id="se.cascable.client.help.supported-cameras.nikon-models">
 	<li>D3200 (Requires WU-1a WiFi Adapter)</li>
 	<li>D3300 (Requires WU-1a WiFi Adapter)</li>
-	<li>D500</li>
 	<li>D5200 (Requires WU-1a WiFi Adapter)</li>
 	<li>D5300 (Requires WU-1a WiFi Adapter)</li>
 	<li>D5500</li>

--- a/de.lproj/HelpCentre/SupportedCameras/index.html
+++ b/de.lproj/HelpCentre/SupportedCameras/index.html
@@ -34,7 +34,6 @@
 <ul id="se.cascable.client.help.supported-cameras.nikon-models">
 	<li>D3200 (WU-1a WLAN-Adapter erforderlich)</li>
 	<li>D3300 (WU-1a WLAN-Adapter erforderlich)</li>
-	<li>D500</li>
 	<li>D5200 (WU-1a WLAN-Adapter erforderlich)</li>
 	<li>D5300 (WU-1a WLAN-Adapter erforderlich)</li>
 	<li>D5500</li>


### PR DESCRIPTION
Nikon D500 removed from Supported Cameras Help Centre article (English and German localisations).

--Tim