### PR TITLE
Add new supported cameras to Help Centre

### DIFF
--- a/Base.lproj/HelpCentre/SupportedCameras/index.html
+++ b/Base.lproj/HelpCentre/SupportedCameras/index.html
@@ -16,12 +16,16 @@
 <a name="canon"></a>
 <h3>Canon</h3>
 <ul id="se.cascable.client.help.supported-cameras.canon-models">
-	<li>EOS 1300D, Rebel T6</li>
+	<li>EOS 5D Mark IV</li>
+	<li>EOS 5DS (with W-E1)</li>
+	<li>EOS 5DS R (with W-E1)</li>
 	<li>EOS 6D</li>
-	<li>EOS 70D</li>
-	<li>EOS 750D, T6i</li>
-	<li>EOS 760D, T6s</li>
+	<li>EOS 7D Mark II (with W-E1)</li>
 	<li>EOS 80D</li>
+	<li>EOS 70D</li>
+	<li>EOS 760D, T6s</li>
+	<li>EOS 750D, T6i</li>
+	<li>EOS 1300D, T6</li>
 	<li>EOS M10</li>
 	<li>EOS M2</li>
 	<li>EOS M3</li>
@@ -32,17 +36,17 @@
 <a name="nikon"></a>
 <h3>Nikon</h3>
 <ul id="se.cascable.client.help.supported-cameras.nikon-models">
-	<li>D3200 (Requires WU-1a WiFi Adapter)</li>
-	<li>D3300 (Requires WU-1a WiFi Adapter)</li>
-	<li>D5200 (Requires WU-1a WiFi Adapter)</li>
-	<li>D5300 (Requires WU-1a WiFi Adapter)</li>
+	<li>D3200 (with WU-1a)</li>
+	<li>D3300 (with WU-1a)</li>
+	<li>D5200 (with WU-1a)</li>
+	<li>D5300 (with WU-1a)</li>
 	<li>D5500</li>
-	<li>D600 (Requires WU-1b WiFi Adapter)</li>
-	<li>D610 (Requires WU-1b WiFi Adapter)</li>
-	<li>D7100 (Requires WU-1a WiFi Adapter)</li>
+	<li>D600 (with WU-1b)</li>
+	<li>D610 (with WU-1b)</li>
+	<li>D7100 (with WU-1a)</li>
 	<li>D7200</li>
 	<li>D750</li>
-	<li>Df (Requires WU-1a WiFi Adapter)</li>
+	<li>Df (with WU-1a)</li>
 </ul>
 
 <hr>

--- a/de.lproj/HelpCentre/SupportedCameras/index.html
+++ b/de.lproj/HelpCentre/SupportedCameras/index.html
@@ -16,12 +16,16 @@
 <a name="canon"></a>
 <h3>Canon</h3>
 <ul id="se.cascable.client.help.supported-cameras.canon-models">
-	<li>EOS 1300D, Rebel T6</li>
+	<li>EOS 5D Mark IV</li>
+	<li>EOS 5DS (W-E1 WLAN-Adapter erforderlich)</li>
+	<li>EOS 5DS R (W-E1 WLAN-Adapter erforderlich)</li>
 	<li>EOS 6D</li>
-	<li>EOS 70D</li>
-	<li>EOS 750D, T6i</li>
-	<li>EOS 760D, T6s</li>
+	<li>EOS 7D Mark II (W-E1 WLAN-Adapter erforderlich)</li>
 	<li>EOS 80D</li>
+	<li>EOS 70D</li>
+	<li>EOS 760D, T6s</li>
+	<li>EOS 750D, T6i</li>
+	<li>EOS 1300D, T6</li>
 	<li>EOS M10</li>
 	<li>EOS M2</li>
 	<li>EOS M3</li>

--- a/en.lproj/HelpCentre/SupportedCameras/index.html
+++ b/en.lproj/HelpCentre/SupportedCameras/index.html
@@ -16,12 +16,16 @@
 <a name="canon"></a>
 <h3>Canon</h3>
 <ul id="se.cascable.client.help.supported-cameras.canon-models">
-	<li>EOS 1300D, Rebel T6</li>
+	<li>EOS 5D Mark IV</li>
+	<li>EOS 5DS (with W-E1)</li>
+	<li>EOS 5DS R (with W-E1)</li>
 	<li>EOS 6D</li>
-	<li>EOS 70D</li>
-	<li>EOS 750D, T6i</li>
-	<li>EOS 760D, T6s</li>
+	<li>EOS 7D Mark II (with W-E1)</li>
 	<li>EOS 80D</li>
+	<li>EOS 70D</li>
+	<li>EOS 760D, T6s</li>
+	<li>EOS 750D, T6i</li>
+	<li>EOS 1300D, T6</li>
 	<li>EOS M10</li>
 	<li>EOS M2</li>
 	<li>EOS M3</li>
@@ -32,17 +36,17 @@
 <a name="nikon"></a>
 <h3>Nikon</h3>
 <ul id="se.cascable.client.help.supported-cameras.nikon-models">
-	<li>D3200 (Requires WU-1a WiFi Adapter)</li>
-	<li>D3300 (Requires WU-1a WiFi Adapter)</li>
-	<li>D5200 (Requires WU-1a WiFi Adapter)</li>
-	<li>D5300 (Requires WU-1a WiFi Adapter)</li>
+	<li>D3200 (with WU-1a)</li>
+	<li>D3300 (with WU-1a)</li>
+	<li>D5200 (with WU-1a)</li>
+	<li>D5300 (with WU-1a)</li>
 	<li>D5500</li>
-	<li>D600 (Requires WU-1b WiFi Adapter)</li>
-	<li>D610 (Requires WU-1b WiFi Adapter)</li>
-	<li>D7100 (Requires WU-1a WiFi Adapter)</li>
+	<li>D600 (with WU-1b)</li>
+	<li>D610 (with WU-1b)</li>
+	<li>D7100 (with WU-1a)</li>
 	<li>D7200</li>
 	<li>D750</li>
-	<li>Df (Requires WU-1a WiFi Adapter)</li>
+	<li>Df (with WU-1a)</li>
 </ul>
 
 <hr>


### PR DESCRIPTION
This PR adds the following cameras to **Help & Information** → **Supported Camera Models** in `Base.lproj`, `en.lproj`, and `de.lproj`:

- EOS 5D Mark IV
- EOS 5DS (with W-E1)
- EOS 5DS R (with W-E1)
- EOS 7D Mark II (with W-E1)

The Canon models in the **Supported Camera Models** article have also been reordered to match the  order used on the `https://cascable.se/help/compatibility/` web page.

–Tim