### PR TITLE
CBL-712: Add EOS M5 to supported cameras list

### DIFF
--- a/Base.lproj/HelpCentre/SupportedCameras/index.html
+++ b/Base.lproj/HelpCentre/SupportedCameras/index.html
@@ -26,9 +26,10 @@
 	<li>EOS 760D, T6s</li>
 	<li>EOS 750D, T6i</li>
 	<li>EOS 1300D, T6</li>
+	<li>EOS M5</li>
+	<li>EOS M3</li>
 	<li>EOS M10</li>
 	<li>EOS M2</li>
-	<li>EOS M3</li>
 </ul>
 
 <hr>

--- a/de.lproj/HelpCentre/SupportedCameras/index.html
+++ b/de.lproj/HelpCentre/SupportedCameras/index.html
@@ -26,9 +26,10 @@
 	<li>EOS 760D, T6s</li>
 	<li>EOS 750D, T6i</li>
 	<li>EOS 1300D, T6</li>
+	<li>EOS M5</li>
+	<li>EOS M3</li>
 	<li>EOS M10</li>
 	<li>EOS M2</li>
-	<li>EOS M3</li>
 </ul>
 
 <hr>

--- a/en.lproj/HelpCentre/SupportedCameras/index.html
+++ b/en.lproj/HelpCentre/SupportedCameras/index.html
@@ -26,9 +26,10 @@
 	<li>EOS 760D, T6s</li>
 	<li>EOS 750D, T6i</li>
 	<li>EOS 1300D, T6</li>
+	<li>EOS M5</li>
+	<li>EOS M3</li>
 	<li>EOS M10</li>
 	<li>EOS M2</li>
-	<li>EOS M3</li>
 </ul>
 
 <hr>


### PR DESCRIPTION
This pull request adds _EOS M5_ to the supported cameras list `HelpCentre/SupportedCameras/index.html` in `base.lproj`, `en.lproj` and `de.lproj`.

It also reorganises the existing EOS M camera models to match the ordering of other EOS cameras (sort by most new/pro).

--Tim