### PR TITLE
Adds 5D3 (with WFT-E7B) to supported cameras list.

### DIFF
--- a/Base.lproj/HelpCentre/SupportedCameras/index.html
+++ b/Base.lproj/HelpCentre/SupportedCameras/index.html
@@ -19,7 +19,7 @@
 	<li>EOS 5D Mark IV</li>
 	<li>EOS 5DS (with W-E1)</li>
 	<li>EOS 5DS R (with W-E1)</li>
-	<li>EOS 5D Mark III (with WFT-E7B)</li>
+	<li>EOS 5D Mark III (with WFT-E7)</li>
 	<li>EOS 6D</li>
 	<li>EOS 7D Mark II (with W-E1)</li>
 	<li>EOS 80D</li>

--- a/Base.lproj/HelpCentre/SupportedCameras/index.html
+++ b/Base.lproj/HelpCentre/SupportedCameras/index.html
@@ -19,6 +19,7 @@
 	<li>EOS 5D Mark IV</li>
 	<li>EOS 5DS (with W-E1)</li>
 	<li>EOS 5DS R (with W-E1)</li>
+	<li>EOS 5D Mark III (with WFT-E7B)</li>
 	<li>EOS 6D</li>
 	<li>EOS 7D Mark II (with W-E1)</li>
 	<li>EOS 80D</li>

--- a/de.lproj/HelpCentre/SupportedCameras/index.html
+++ b/de.lproj/HelpCentre/SupportedCameras/index.html
@@ -19,7 +19,7 @@
 	<li>EOS 5D Mark IV</li>
 	<li>EOS 5DS (mit W-E1)</li>
 	<li>EOS 5DS R (mit W-E1)</li>
-	<li>EOS 5D Mark III (mit WFT-E7B)</li>
+	<li>EOS 5D Mark III (mit WFT-E7)</li>
 	<li>EOS 6D</li>
 	<li>EOS 7D Mark II (mit W-E1)</li>
 	<li>EOS 80D</li>

--- a/de.lproj/HelpCentre/SupportedCameras/index.html
+++ b/de.lproj/HelpCentre/SupportedCameras/index.html
@@ -19,6 +19,7 @@
 	<li>EOS 5D Mark IV</li>
 	<li>EOS 5DS (mit W-E1)</li>
 	<li>EOS 5DS R (mit W-E1)</li>
+	<li>EOS 5D Mark III (mit WFT-E7B)</li>
 	<li>EOS 6D</li>
 	<li>EOS 7D Mark II (mit W-E1)</li>
 	<li>EOS 80D</li>

--- a/en.lproj/HelpCentre/SupportedCameras/index.html
+++ b/en.lproj/HelpCentre/SupportedCameras/index.html
@@ -19,7 +19,7 @@
 	<li>EOS 5D Mark IV</li>
 	<li>EOS 5DS (with W-E1)</li>
 	<li>EOS 5DS R (with W-E1)</li>
-	<li>EOS 5D Mark III (with WFT-E7B)</li>
+	<li>EOS 5D Mark III (with WFT-E7)</li>
 	<li>EOS 6D</li>
 	<li>EOS 7D Mark II (with W-E1)</li>
 	<li>EOS 80D</li>

--- a/en.lproj/HelpCentre/SupportedCameras/index.html
+++ b/en.lproj/HelpCentre/SupportedCameras/index.html
@@ -19,6 +19,7 @@
 	<li>EOS 5D Mark IV</li>
 	<li>EOS 5DS (with W-E1)</li>
 	<li>EOS 5DS R (with W-E1)</li>
+	<li>EOS 5D Mark III (with WFT-E7B)</li>
 	<li>EOS 6D</li>
 	<li>EOS 7D Mark II (with W-E1)</li>
 	<li>EOS 80D</li>


### PR DESCRIPTION
This pull request adds _EOS 5D Mark III (with WFT-E7B)_ to the supported cameras list `HelpCentre/SupportedCameras/index.html` in `base.lproj`, `en.lproj` and `de.lproj`.

The 5D3 appears below the 5Ds/r, but above the 6D.

--Tim