### PR TITLE
Add α7S II to supported cameras list

### DIFF
--- a/Base.lproj/HelpCentre/SupportedCameras/index.html
+++ b/Base.lproj/HelpCentre/SupportedCameras/index.html
@@ -76,11 +76,13 @@
 <a name="sony"></a>
 <h3>Sony</h3>
 <ul id="se.cascable.client.help.supported-cameras.sony-models">
-	<li>α7</li>
 	<li>α7 II</li>
-	<li>α7R</li>
+	<li>α7</li>
 	<li>α7R II</li>
+	<li>α7R</li>
+	<li>α7S II</li>
 	<li>α7S</li>
+	<li>α7S II</li>
 	<li>α5000</li>
 	<li>α5100</li>
 	<li>α6000</li>

--- a/de.lproj/HelpCentre/SupportedCameras/index.html
+++ b/de.lproj/HelpCentre/SupportedCameras/index.html
@@ -81,6 +81,7 @@
 	<li>α7R</li>
 	<li>α7R II</li>
 	<li>α7S</li>
+	<li>α7S II</li>
 	<li>α5000</li>
 	<li>α5100</li>
 	<li>α6000</li>

--- a/en.lproj/HelpCentre/SupportedCameras/index.html
+++ b/en.lproj/HelpCentre/SupportedCameras/index.html
@@ -81,6 +81,7 @@
 	<li>α7R</li>
 	<li>α7R II</li>
 	<li>α7S</li>
+	<li>α7S II</li>
 	<li>α5000</li>
 	<li>α5100</li>
 	<li>α6000</li>


### PR DESCRIPTION
This PR adds **Sony α7S II** to the Supported Cameras article in `Base.lproj`, `en.lproj` and `de.lproj`.

--Tim